### PR TITLE
Update dashboard and header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,12 +5,15 @@ import Avatar from '@mui/material/Avatar';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import SearchIcon from '@mui/icons-material/Search';
 import UserMenu from "./UserMenu";
+import PlatformMenu from "./PlatformMenu";
 
 function Header() {
   const [user, setUser] = useState({ email: "", name: "", id: null });
   const [menuVisible, setMenuVisible] = useState(false);
+  const [appsVisible, setAppsVisible] = useState(false);
   const navigate = useNavigate();
   const menuRef = useRef(null);
+  const appsRef = useRef(null);
 
   useEffect(() => {
     getAccountDetails()
@@ -44,10 +47,17 @@ function Header() {
     setMenuVisible((prev) => !prev);
   };
 
+  const toggleApps = () => {
+    setAppsVisible((prev) => !prev);
+  };
+
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (menuRef.current && !menuRef.current.contains(event.target)) {
         setMenuVisible(false);
+      }
+      if (appsRef.current && !appsRef.current.contains(event.target)) {
+        setAppsVisible(false);
       }
     };
   
@@ -102,7 +112,8 @@ function Header() {
         </div>
 
         <div className="user-menu d-flex align-items-center" ref={menuRef} style={{ position: "relative" }}>
-          <ul className="nav-list">
+          <ul className="nav-list" style={{ marginRight: "20px" }}>
+            <li onClick={toggleApps} style={{ cursor: "pointer" }}>Apps</li>
             <li>
               <Link to="/account/pricing">Pricing</Link>
             </li>
@@ -113,6 +124,11 @@ function Header() {
 
           {menuVisible && (
             <UserMenu user={user} onLogout={handleLogout} />
+          )}
+          {appsVisible && (
+            <div ref={appsRef}>
+              <PlatformMenu />
+            </div>
           )}
         </div>
       </header>

--- a/src/components/PlatformMenu.jsx
+++ b/src/components/PlatformMenu.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { huberwayLinks } from "../data/platforms";
+
+const PlatformMenu = () => {
+  return (
+    <div
+      className="platform-menu"
+      style={{
+        position: "absolute",
+        top: "60px",
+        left: "0",
+        backgroundColor: "#ffffff",
+        boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+        borderRadius: "10px",
+        padding: "20px",
+        zIndex: 1000,
+        width: "320px",
+      }}
+    >
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {huberwayLinks.map((app) => (
+          <li key={app.name} style={{ marginBottom: "10px" }}>
+            <a
+              href={app.url}
+              onClick={(e) => app.url === "#" && e.preventDefault()}
+              style={{
+                textDecoration: "none",
+                color: "#0039A9",
+                fontWeight: "bold",
+                display: "flex",
+                alignItems: "center",
+                gap: "10px",
+              }}
+            >
+              {app.icons && (
+                <img src={app.icons[0]} alt="" style={{ height: "20px" }} />
+              )}
+              {app.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default PlatformMenu;

--- a/src/data/platforms.js
+++ b/src/data/platforms.js
@@ -1,0 +1,35 @@
+export const huberwayLinks = [
+  {
+    name: "HubConnect",
+    description: "Centralized management of Sales and marketing",
+    url: "https://app.huberway.com",
+    icons: [
+      "https://dev.huberway.com/icon/sales.svg",
+    ],
+  },
+  {
+    name: "MailMaster",
+    description: "Centralized management of Email Marketing & Automation",
+    url: "https://campaign.huberway.com",
+    icons: [
+      "https://dev.huberway.com/icon/marketing.svg",
+    ],
+  },
+  {
+    name: "SmartChat AI",
+    description: "Support your customers with AI-powered chatbots",
+    url: "#",
+    icons: ["https://dev.huberway.com/icon/smartchat.svg"],
+  },
+  {
+    name: "ContentFlow",
+    description: "Content management, E-Commerce and Web App Development",
+    url: "#",
+    icons: ["https://dev.huberway.com/icon/content.svg"],
+  },
+  {
+    name: "Web Analytics",
+    description: "Detailed analysis of traffic and conversions",
+    url: "https://analytics.huberway.com",
+  },
+];

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -3,6 +3,8 @@ import { useNavigate, Link } from "react-router-dom";
 import { getAccountDetails, getClientApps } from "../backend/api";
 import Header from "../components/Header";
 import ImportWizardModal from "../components/ImportWizardModal";
+import { huberwayLinks } from "../data/platforms";
+import ProgressBar from "./ProgressBar";
 
 
 const Dashboard = () => {
@@ -51,41 +53,6 @@ const Dashboard = () => {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const huberwayLinks = [
-    {
-      name: "HubConnect",
-      description: "Centralized management of Sales and marketing",
-      url: "https://app.huberway.com",
-      icons: [
-        "https://dev.huberway.com/icon/sales.svg",
-      ],
-    },
-      {
-        name: "MailMaster",
-        description: "Centralized management of Email Marketing & Automation",
-        url: "https://campaign.huberway.com",
-        icons: [
-           "https://dev.huberway.com/icon/marketing.svg",
-        ],
-      },
-    {
-      name: "SmartChat AI",
-      description: "Support your customers with AI-powered chatbots",
-      url: "#",
-      icons: ["https://dev.huberway.com/icon/smartchat.svg"],
-    },
-    {
-      name: "ContentFlow",
-      description: "Content management, E-Commerce and Web App Development",
-      url: "#",
-      icons: ["https://dev.huberway.com/icon/content.svg"],
-    },
-    {
-      name: "Web Analytics",
-      description: "Detailed analysis of traffic and conversions",
-      url: "https://analytics.huberway.com",
-    },
-  ];
 
   return (
     <div className="dashboard-container">
@@ -160,6 +127,37 @@ const Dashboard = () => {
               </a>
             ))}
           </div>
+        </section>
+
+        <section>
+          <h2>Reporting</h2>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Platform</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {huberwayLinks.map((app) => (
+                <tr key={app.name}>
+                  <td>{app.name}</td>
+                  <td>{app.url === "#" ? "Coming Soon" : "Active"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section>
+          <h2>Info & Academy</h2>
+          <p>Stay updated with Huberway news and marketing resources.</p>
+        </section>
+
+        <section>
+          <h2>Onboarding Progress</h2>
+          <ProgressBar progress={30} />
+          <p className="text-information">Complete the tasks to reach the next level.</p>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- centralize platform links data
- implement new dropdown to access platforms from header
- show reporting, academy info, and onboarding progress in dashboard

## Testing
- `npm test --silent --forceExit` *(fails: useLocation may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_684061fa47788324aac39cd544a332ce